### PR TITLE
fix: Correct Typo + Add target in Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
                             une gestion de l'historique des coups joués) et se trouve ici :
                         </p>
                         <p>
-                            <a href="https://fr.reactjs.org/tutorial/tutorial.html"
+                            <a href="https://fr.reactjs.org/tutorial/tutorial.html" target="_blank"
                                 >https://fr.reactjs.org/tutorial/tutorial.html</a
                             >
                         </p>
@@ -604,15 +604,15 @@
                     </section>
 
                     <section>
-                        <h3>Premiers comosants</h3>
+                        <h3>Premiers composants</h3>
                         <ol>
-                            <li>Installer node.js (LTS) <a href="https://nodejs.org/en/">https://nodejs.org/en/</a></li>
+                            <li>Installer node.js (LTS) <a href="https://nodejs.org/en/" target="_blank">https://nodejs.org/en/</a></li>
                             <li>
                                 Installer create-react-app : <span style="color: pink">npm i –g create-react-app</span>
                             </li>
                             <li>
                                 Installer vscode
-                                <a href="https://code.visualstudio.com/">https://code.visualstudio.com/</a> (plugins:
+                                <a href="https://code.visualstudio.com/" target="_blank">https://code.visualstudio.com/</a> (plugins:
                                 auto close tag, auto rename tag, eslint, prettier)
                             </li>
                             <li>Créer un projet : <span style="color: pink">npx create-react-app todo-app</span></li>
@@ -738,7 +738,7 @@
                             objet qui mette à jour l'état, soit null.
                         </p>
                         <p>Cette méthode existe pour les rares cas où le state dépend des props reçues.</p>
-                        <p>Cette méthode est n'a pas accès à l'instance de composant (this).</p>
+                        <p>Cette méthode n'a pas accès à l'instance de composant (this).</p>
                     </section>
 
                     <section>
@@ -827,7 +827,7 @@
                     </section>
 
                     <section>
-                        <h3>vgetSnapshotBeforeUpdate(prevProps, prevState)</h3>
+                        <h3>getSnapshotBeforeUpdate(prevProps, prevState)</h3>
                         <p>Est appelé juste avant que le rendu le plus récent ne soit validé.</p>
                         <p>
                             Elle permet par exemple de récupérer les informations du DOM avant leur modification. Toute
@@ -989,7 +989,7 @@
                             DOM.
                         </p>
                         <p>
-                            Le but de <a href="https://fr.reactjs.org/docs/fragments.html">Fragment</a> est de résoudre
+                            Le but de <a href="https://fr.reactjs.org/docs/fragments.html" target="_blank">Fragment</a> est de résoudre
                             ce problème.
                         </p>
                         <p>Une utilisation courante sera notamment avec les tableaux</p>
@@ -1045,7 +1045,7 @@
                     <section>
                         <h3>Hooks</h3>
                         <p>
-                            <a href="https://fr.reactjs.org/docs/hooks-intro.html">Hooks</a> est la dernière nouveauté
+                            <a href="https://fr.reactjs.org/docs/hooks-intro.html" target="_blank">Hooks</a> est la dernière nouveauté
                             de React. L’idée est de pouvoir utiliser les comportements de cycle de vie ainsi que le
                             state dans des composants fonctions (ces derniers n’étaient auparavant disponible que pour
                             les composant de type class).
@@ -1066,12 +1066,12 @@
                         <h3>Hooks</h3>
                         <ul>
                             <li>
-                                <a href="https://medium.com/@dan_abramov/making-sense-of-react-hooks-fdbde8803889"
+                                <a href="https://medium.com/@dan_abramov/making-sense-of-react-hooks-fdbde8803889" target="_blank"
                                     >https://medium.com/@dan_abramov/making-sense-of-react-hooks-fdbde8803889</a
                                 >
                             </li>
                             <li>
-                                <a href="https://wattenberger.com/blog/react-hooks"
+                                <a href="https://wattenberger.com/blog/react-hooks" target="_blank"
                                     >https://wattenberger.com/blog/react-hooks</a
                                 >
                             </li>
@@ -1112,7 +1112,7 @@
                     <section>
                         <h3>Layout</h3>
                         <p>Proposition de librairie :</p>
-                        <p><a href="https://material-ui.com/fr/">https://material-ui.com/fr/</a></p>
+                        <p><a href="https://material-ui.com/fr/" target="_blank">https://material-ui.com/fr/</a></p>
                         <img src="img/layout.png" alt="Layout" />
                     </section>
                 </section>
@@ -1126,7 +1126,7 @@
                         <h3>Routing</h3>
                         <p>Proposition de librairie :</p>
                         <p>
-                            <a href="https://reacttraining.com/react-router/web/guides/quick-start"
+                            <a href="https://reacttraining.com/react-router/web/guides/quick-start" target="_blank"
                                 >https://reacttraining.com/react-router/web/guides/quick-start</a
                             >
                         </p>
@@ -1142,7 +1142,7 @@
                         <h3>Appeler le serveur</h3>
                         <p>Utilisation de fetch :</p>
                         <p>
-                            <a href="https://developer.mozilla.org/fr/docs/Web/API/Fetch_API"
+                            <a href="https://developer.mozilla.org/fr/docs/Web/API/Fetch_API" target="_blank"
                                 >https://developer.mozilla.org/fr/docs/Web/API/Fetch_API</a
                             >
                         </p>


### PR DESCRIPTION
Correction of some typo 
Add target blank in "href" to open in new tab for link